### PR TITLE
✨ feat : 사진 그림 그릴 때 자동저장 되지 않는 로직 추가 | 이영준 | DrawingPadFragment

### DIFF
--- a/frontend/likloud/app/src/main/java/com/ssafy/likloud/ui/drawingpad/DrawingPadFragment.kt
+++ b/frontend/likloud/app/src/main/java/com/ssafy/likloud/ui/drawingpad/DrawingPadFragment.kt
@@ -50,6 +50,7 @@ import com.ssafy.likloud.ui.drawingpad.BitmapCanvasObject.selectedEraserStrokeWi
 import com.ssafy.likloud.ui.drawingpad.BitmapCanvasObject.selectedStrokeWidth
 import com.ssafy.likloud.util.createMultipartFromUri
 import com.ssafy.likloud.util.createMultipartFromUriNameFile
+import com.ssafy.likloud.util.deleteImageFromGallery
 import com.ssafy.likloud.util.makeButtonAnimationX
 import com.ssafy.likloud.util.makeButtonAnimationXWithDuration
 import com.ssafy.likloud.util.saveImageToGallery
@@ -79,8 +80,6 @@ class DrawingPadFragment : BaseFragment<FragmentDrawingPadBinding>(
     private val largerWeight = 1.2f
     private val originalWeight = 1.0f
     private lateinit var layoutListener: OnGlobalLayoutListener
-
-
 
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -116,14 +115,17 @@ class DrawingPadFragment : BaseFragment<FragmentDrawingPadBinding>(
 
     private fun initView() {
 
-        binding.seekbarEraser.trackActiveTintList = ColorStateList.valueOf(resources.getColor(R.color.eraser))
+        binding.seekbarEraser.trackActiveTintList =
+            ColorStateList.valueOf(resources.getColor(R.color.eraser))
         // 초기 펜 스타일 현재 글자 크기로 지정
         setDotAndButtonView()
         val layoutParams = binding.dotPensize.layoutParams as ConstraintLayout.LayoutParams
-        layoutParams.height = (selectedStrokeWidth *0.15) .toInt()  * mActivity.resources.getDimensionPixelSize(com.intuit.sdp.R.dimen._1sdp) + 1
+        layoutParams.height =
+            (selectedStrokeWidth * 0.15).toInt() * mActivity.resources.getDimensionPixelSize(com.intuit.sdp.R.dimen._1sdp) + 1
 
-        
-        layoutParams.width = (selectedStrokeWidth  *0.15) .toInt()  * mActivity.resources.getDimensionPixelSize(com.intuit.sdp.R.dimen._1sdp) + 1
+
+        layoutParams.width =
+            (selectedStrokeWidth * 0.15).toInt() * mActivity.resources.getDimensionPixelSize(com.intuit.sdp.R.dimen._1sdp) + 1
         binding.dotPensize.layoutParams = layoutParams
         binding.dotPensize.requestLayout()
 
@@ -189,7 +191,6 @@ class DrawingPadFragment : BaseFragment<FragmentDrawingPadBinding>(
         }
 
 
-
 //        layoutListener = OnGlobalLayoutListener {
 //            if (imageViewHeight != binding.imageChosenPhoto.height) {
 //                binding.cardviewCanvas.visibility = View.VISIBLE
@@ -206,18 +207,22 @@ class DrawingPadFragment : BaseFragment<FragmentDrawingPadBinding>(
         binding.buttonSaveDrawing.setOnClickListener {
             bmp = viewToBitmap(binding.canvasDrawingpad)
             mainActivityViewModel.setDrawingBitmap(bmp!!)
+            var savedImageUri = saveImageToGallery(
+                requireContext(),
+                bmp!!,
+                SimpleDateFormat("yyMMdd_HHmmss").format(Date())
+            )
             mainActivityViewModel.setDrawingMultipart(
                 createMultipartFromUriNameFile(
                     requireContext(),
                     Uri.parse(
-                        saveImageToGallery(
-                            requireContext(),
-                            bmp!!,
-                            SimpleDateFormat("yyMMdd_HHmmss").format(Date())
-                        )
+                        savedImageUri
                     )
                 )!!
             )
+            if (savedImageUri != null) {
+                deleteImageFromGallery(requireContext(),savedImageUri)
+            }
             findNavController().navigate(R.id.action_drawingPadFragment_to_drawingFormFragment)
         }
 
@@ -226,8 +231,10 @@ class DrawingPadFragment : BaseFragment<FragmentDrawingPadBinding>(
             addOnChangeListener(Slider.OnChangeListener { slider, value, fromUser ->
                 selectedStrokeWidth = value
                 val layoutParams = binding.dotPensize.layoutParams as ConstraintLayout.LayoutParams
-                layoutParams.width = (value*0.15) .toInt()  * mActivity.resources.getDimensionPixelSize(com.intuit.sdp.R.dimen._1sdp) + 1
-                layoutParams.height = (value*0.15).toInt() * mActivity.resources.getDimensionPixelSize(com.intuit.sdp.R.dimen._1sdp) + 1
+                layoutParams.width =
+                    (value * 0.15).toInt() * mActivity.resources.getDimensionPixelSize(com.intuit.sdp.R.dimen._1sdp) + 1
+                layoutParams.height =
+                    (value * 0.15).toInt() * mActivity.resources.getDimensionPixelSize(com.intuit.sdp.R.dimen._1sdp) + 1
                 binding.dotPensize.layoutParams = layoutParams
                 binding.dotPensize.requestLayout()
             })
@@ -304,7 +311,7 @@ class DrawingPadFragment : BaseFragment<FragmentDrawingPadBinding>(
      * 펜 스타일 패드를 숨깁니다.
      */
     private fun movePenWithLayoutToLeft() {
-        if(!isPenStylePadOpened) return
+        if (!isPenStylePadOpened) return
         isPenStylePadOpened = false
         makeButtonAnimationX(binding.layoutPenEraserWidth, DRAWING_STYLE_PAD_LEFT)
     }
@@ -313,7 +320,7 @@ class DrawingPadFragment : BaseFragment<FragmentDrawingPadBinding>(
      * 펜스타일 패드를 보여줍니다.
      */
     private fun movePenWithLayoutToRight() {
-        if(isPenStylePadOpened) return
+        if (isPenStylePadOpened) return
         isPenStylePadOpened = true
         makeButtonAnimationX(binding.layoutPenEraserWidth, 0f)
     }
@@ -401,7 +408,10 @@ class DrawingPadFragment : BaseFragment<FragmentDrawingPadBinding>(
             .load(mainActivityViewModel.uploadingPhotoUrl.value)
             .fitCenter()
             .into(object : CustomTarget<Drawable>() {
-                override fun onResourceReady(resource: Drawable, transition: Transition<in Drawable>?) {
+                override fun onResourceReady(
+                    resource: Drawable,
+                    transition: Transition<in Drawable>?
+                ) {
                     // 로딩 다이얼로그 닫기
                     dismissLoadingDialog()
 
@@ -462,7 +472,6 @@ class DrawingPadFragment : BaseFragment<FragmentDrawingPadBinding>(
 //            }
 //        }
 //        binding.imageChosenPhoto.viewTreeObserver.addOnGlobalLayoutListener(layoutListener)
-
 
 
         loadImage()

--- a/frontend/likloud/app/src/main/java/com/ssafy/likloud/ui/upload/UploadFragment.kt
+++ b/frontend/likloud/app/src/main/java/com/ssafy/likloud/ui/upload/UploadFragment.kt
@@ -87,14 +87,10 @@ class UploadFragment :
         }
     }
 
-
-    private val requestMultiplePermission =
-        registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { results ->
-            results.forEach {
-                Log.d(TAG, "${it.key} : ${it.value}")
-            }
-        }
-
+    /**
+     * 권한 설정 TedPermissionDialog를 띄웁니다.
+     * 이미 거부한 경우, snackbar를 띄워 앱 설정으로 이동하게끔 합니다.
+     */
     private fun createPermissionDialog() {
         TedPermission.create().setPermissionListener(object : PermissionListener {
 
@@ -105,7 +101,8 @@ class UploadFragment :
 
                 //권한이 거부됐을 때
                 override fun onPermissionDenied(deniedPermissions: MutableList<String>?) {
-                    showSnackbar(binding.root, "failAndMoveToAppSettings", "애플리케이션 설정에서 카메라 및 저장소 권한을 허용해 주세요")
+                    showSnackbar(binding.root, "failAndMoveToAppSettings",
+                        getString(R.string.app_permission))
 
 
                 }

--- a/frontend/likloud/app/src/main/java/com/ssafy/likloud/util/PhotoToMultipartConverter.kt
+++ b/frontend/likloud/app/src/main/java/com/ssafy/likloud/util/PhotoToMultipartConverter.kt
@@ -120,6 +120,24 @@ fun saveImageToGallery(context: Context, bitmap: Bitmap, displayName: String): S
     return null
 }
 
+fun deleteImageFromGallery(context: Context, imageUri: String): Boolean {
+    val contentResolver: ContentResolver = context.contentResolver
+    try {
+        // 이미지 URI를 Uri 객체로 파싱
+        val uri = Uri.parse(imageUri)
+
+        // 해당 이미지 삭제
+        val deleted = contentResolver.delete(uri, null, null)
+
+        // 삭제 성공 여부 반환
+        return deleted > 0
+    } catch (e: Exception) {
+        // 삭제 실패 시 예외 처리
+        e.printStackTrace()
+    }
+    return false
+}
+
 
 fun dontSaveImageToGallery(context: Context, bitmap: Bitmap, displayName: String): String? {
     val contentResolver: ContentResolver = context.contentResolver

--- a/frontend/likloud/app/src/main/res/values/strings.xml
+++ b/frontend/likloud/app/src/main/res/values/strings.xml
@@ -20,6 +20,7 @@
     <string name="camera">카메라</string>
     <string name="how_to_upload">어떻게 사진을 업로드 할까요?</string>
     <string name="camera_permission">카메라 및 저장소 권한을 허용해 주세요</string>
+    <string name="app_permission">애플리케이션 설정에서 카메라 및 저장소 권한을 허용해 주세요</string>
 
     <!--drawingList-->
     <string name="title_drawingList">그림목록</string>
@@ -153,5 +154,6 @@
     <string name="drawing_pad">그림판</string>
     <string name="original_look">이렇게 생겼어요!</string>
     <string name="quit_user">탈퇴하기</string>
+
 
 </resources>


### PR DESCRIPTION
Utils에 deleteImageFromGallery 코드를 추가해서
그림을 업로드하면 갤러리에 저장되었다가 즉시 삭제하여 그린 그림이 갤러리에 자동저장되지 않도록 하였습니다.